### PR TITLE
Use falsy default for cover resource

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -34,7 +34,7 @@
               {{ $imagePath = . }}
             {{ end }}
           {{ end }}
-          {{ $coverResource := nil }}
+          {{ $coverResource := false }}
           {{ if $imagePath }}
             {{ with $page.Resources.GetMatch $imagePath }}
               {{ $coverResource = . }}


### PR DESCRIPTION
## Summary
- initialize the list template's cover resource variable with a falsy default that Hugo accepts

## Testing
- `hugo --minify` *(fails: command not found: hugo)*

------
https://chatgpt.com/codex/tasks/task_e_68d20568db188322bd20184f010aca6a