### PR TITLE
Handle OpenAI rate limits in RSS script

### DIFF
--- a/scripts/rss_to_hugo_ai.py
+++ b/scripts/rss_to_hugo_ai.py
@@ -5,6 +5,7 @@ import feedparser, requests
 from bs4 import BeautifulSoup
 from slugify import slugify
 from tenacity import retry, wait_exponential, stop_after_attempt
+from email.utils import parsedate_to_datetime
 
 FEED_URL   = os.environ.get("FEED_URL", "https://news.yahoo.co.jp/rss/topics/entertainment.xml")
 POSTS_DIR  = os.environ.get("HUGO_POSTS_DIR", "content/posts")
@@ -73,7 +74,37 @@ def openai_headers():
         "Content-Type": "application/json",
     }
 
-@retry(wait=wait_exponential(multiplier=1, min=1, max=20), stop=stop_after_attempt(3))
+def _retry_after_seconds(response):
+    header = response.headers.get("Retry-After")
+    if not header:
+        return None
+    try:
+        return max(0, int(float(header)))
+    except (TypeError, ValueError):
+        try:
+            retry_dt = parsedate_to_datetime(header)
+        except (TypeError, ValueError):
+            return None
+        if retry_dt is None:
+            return None
+        if retry_dt.tzinfo is None:
+            retry_dt = retry_dt.replace(tzinfo=datetime.timezone.utc)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        return max(0, (retry_dt - now).total_seconds())
+
+
+def _handle_rate_limit(response, context):
+    if response.status_code != 429:
+        return
+    wait_for = _retry_after_seconds(response)
+    if not wait_for:
+        wait_for = 30
+    wait_for = max(wait_for, 10)
+    print(f"OpenAI rate limit hit during {context}. Waiting {int(wait_for)}s before retrying...", flush=True)
+    time.sleep(wait_for)
+
+
+@retry(wait=wait_exponential(multiplier=1, min=1, max=20), stop=stop_after_attempt(5))
 def gen_article(title, url, summary):
     payload = {
         "model": LLM_MODEL,
@@ -84,10 +115,11 @@ def gen_article(title, url, summary):
         "temperature": 0.7,
     }
     r = requests.post(f"{OPENAI_BASE}/chat/completions", headers=openai_headers(), json=payload, timeout=60)
+    _handle_rate_limit(r, "article generation")
     r.raise_for_status()
     return r.json()["choices"][0]["message"]["content"].strip()
 
-@retry(wait=wait_exponential(multiplier=1, min=1, max=20), stop=stop_after_attempt(3))
+@retry(wait=wait_exponential(multiplier=1, min=1, max=20), stop=stop_after_attempt(5))
 def gen_image_png(title):
     prompt = IMG_PROMPT_TEMPLATE.format(title=title)
     payload = {
@@ -97,6 +129,7 @@ def gen_image_png(title):
         "n": 1,
     }
     r = requests.post(f"{OPENAI_BASE}/images/generations", headers=openai_headers(), json=payload, timeout=120)
+    _handle_rate_limit(r, "image generation")
     r.raise_for_status()
     data = r.json()["data"][0]
     if "b64_json" in data:


### PR DESCRIPTION
## Summary
- handle OpenAI 429 responses by pausing according to Retry-After headers before retrying
- increase retry attempts for article and image generation to make rate-limited requests more resilient

## Testing
- python -m compileall scripts/rss_to_hugo_ai.py

------
https://chatgpt.com/codex/tasks/task_e_68d252a750588322892e53e6688e8e15