### PR TITLE
Enable building future-dated content

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -2,6 +2,7 @@ baseURL = "https://kamome12345.github.io/testblog/"
 languageCode = "ja-jp"
 title = "ゴシッぷにゃ"
 theme = "papermod"
+buildFuture = true
 
 # 要約の長さ（一覧で本文を出さず“要約だけ”にする）
 summaryLength = 30


### PR DESCRIPTION
## Summary
- enable future-dated posts to appear by turning on Hugo's buildFuture flag

## Testing
- `hugo` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d347535b6883228a5e4b27bec2dbaa