### PR TITLE
Disable scheduled RSS workflow trigger

### DIFF
--- a/.github/workflows/fetch-ent-ai.yml
+++ b/.github/workflows/fetch-ent-ai.yml
@@ -1,8 +1,8 @@
 name: RSS → AI記事&画像 → Hugo posts
 
 on:
-  schedule:
-    - cron: "0 * * * *"      # UTCで毎時0分（JSTなら毎時9分）
+  # schedule:
+  #   - cron: "0 * * * *"      # UTCで毎時0分（JSTなら毎時9分）
   workflow_dispatch:          # 手動実行
   push:                       # スクリプトやこのYAMLを更新した時にも走る
     paths:


### PR DESCRIPTION
## Summary
- comment out the hourly schedule trigger so the workflow can be run manually only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d53755c798832299fc19cd0b07a020